### PR TITLE
Feature/add openssl scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,7 @@ A browser source showing your currently playing Spotify track for use in streami
 1. Clone the repository
 2. Install dependencies using ``npm i``
 3. Set up an application in the [Spotify developer platform](https://developer.spotify.com/dashboard/applications), and add ``https://localhost/callback`` to the list of Redirect URIs
-4. Create a certificate and private key. If running locally, using [OpenSSL](https://www.openssl.org/) to create a self-signed certificate will suffice. A utility script for development can be found under the tools directory which you must run with privileges (as root).
-```
-cd tools/ 
-sudo ./createCA.sh -b yes
-ls ../src/certs/
-```
+4. Create a certificate and private key. If running locally, using [OpenSSL](https://www.openssl.org/) to create a self-signed certificate will suffice. A utility script for generating development certificates is available via `npm run-script certs`. It will prompt you for a password since it will require root access.
 5. If hosting the application online, I recommend using [Let's Encrypt](https://letsencrypt.org/getting-started/) through [certbot](https://certbot.eff.org/)
 6. Copy ``src/config.example.js`` to ``config.js`` and fill in ``client_id`` and ``client_secret`` found in the dashboard for your Spotify application, as well as changing ``privateKeyPath`` and ``certificatePath`` to point to the certificate and key you just created.
 7. Done! Run using ``npm start``

--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ A browser source showing your currently playing Spotify track for use in streami
 1. Clone the repository
 2. Install dependencies using ``npm i``
 3. Set up an application in the [Spotify developer platform](https://developer.spotify.com/dashboard/applications), and add ``https://localhost/callback`` to the list of Redirect URIs
-4. Create a certificate and private key. If running locally, using [OpenSSL](https://www.openssl.org/) to create a self-signed certificate will suffice. If hosting the application online, I recommend using [Let's Encrypt](https://letsencrypt.org/getting-started/) through [certbot](https://certbot.eff.org/)
-5. Copy ``src/config.example.js`` to ``config.js`` and fill in ``client_id`` and ``client_secret`` found in the dashboard for your Spotify application, as well as changing ``privateKeyPath`` and ``certificatePath`` to point to the certificate and key you just created.
-6. Done! Run using ``npm start``
+4. Create a certificate and private key. If running locally, using [OpenSSL](https://www.openssl.org/) to create a self-signed certificate will suffice. A utility script for development can be found under the tools directory which you must run with privileges (as root).
+```
+cd tools/ 
+sudo ./createCA.sh -b yes
+ls ../src/certs/
+```
+5. If hosting the application online, I recommend using [Let's Encrypt](https://letsencrypt.org/getting-started/) through [certbot](https://certbot.eff.org/)
+6. Copy ``src/config.example.js`` to ``config.js`` and fill in ``client_id`` and ``client_secret`` found in the dashboard for your Spotify application, as well as changing ``privateKeyPath`` and ``certificatePath`` to point to the certificate and key you just created.
+7. Done! Run using ``npm start``

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "devDependencies": {},
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "node src/app.js"
+    "start": "node src/app.js",
+    "certs": "sudo ./tools/createCA.sh -b yes"
   },
   "repository": {
     "type": "git",

--- a/src/app.js
+++ b/src/app.js
@@ -34,3 +34,4 @@ https.createServer({
     key: privateKey,
     cert: certificate
 }, app).listen(config.server.port, () => console.log('listening on', config.server.port))
+

--- a/src/app.js
+++ b/src/app.js
@@ -17,7 +17,6 @@ const config        = require('./config.js')
 const auth          = require('./authentication.js')
 
 const publicPath = path.join(__dirname, '/public')
-const certsPath = path.join(__dirname, '/certs')
 
 app.use(express.static(publicPath)).use(cookieParser()).use(cors())
 
@@ -27,8 +26,8 @@ app.get('/login', (req, res) => auth.login(req, res))
 app.get('/callback', (req, res) => auth.callback(req, res))
 app.get('/refresh_token', (req, res) => auth.refresh_token(req, res))
 
-let privateKey = fs.readFileSync(path.join(certsPath, config.server.privateKeyPath))
-let certificate = fs.readFileSync(path.join(certsPath, config.server.certificatePath))
+let privateKey = fs.readFileSync(path.join(__dirname, config.server.privateKeyPath))
+let certificate = fs.readFileSync(path.join(__dirname, config.server.certificatePath))
 
 https.createServer({
     key: privateKey,

--- a/src/app.js
+++ b/src/app.js
@@ -17,6 +17,8 @@ const config        = require('./config.js')
 const auth          = require('./authentication.js')
 
 const publicPath = path.join(__dirname, '/public')
+const certsPath = path.join(__dirname, '/certs')
+
 app.use(express.static(publicPath)).use(cookieParser()).use(cors())
 
 app.get('/', (req, res) => res.sendFile(path.join(__dirname, '/public/html/index.html')))
@@ -25,8 +27,8 @@ app.get('/login', (req, res) => auth.login(req, res))
 app.get('/callback', (req, res) => auth.callback(req, res))
 app.get('/refresh_token', (req, res) => auth.refresh_token(req, res))
 
-let privateKey = fs.readFileSync(config.server.privateKeyPath)
-let certificate = fs.readFileSync(config.server.certificatePath)
+let privateKey = fs.readFileSync(path.join(certsPath, config.server.privateKeyPath))
+let certificate = fs.readFileSync(path.join(certsPath, config.server.certificatePath))
 
 https.createServer({
     key: privateKey,

--- a/tools/createCA.sh
+++ b/tools/createCA.sh
@@ -60,7 +60,8 @@ installRootCA(){
 	mv "$client_key" ../src/certs/
 	mv "$client_cert" ../src/certs/
 	# Give r-w execution to group's u:o so we can use it for dev! 
-	chmod 755 -R ../src/certs/
+	chmod 755 ../src/certs/"$client_key"
+	chmod 755 ../src/certs/"$client_cert"
 }
 
 # Print help for CLI

--- a/tools/createCA.sh
+++ b/tools/createCA.sh
@@ -56,12 +56,13 @@ verifyCert(){
 # Install into certs folder
 installRootCA(){
 	printf "installing certs\n"
-	mkdir -p ../src/certs/
-	mv "$client_key" ../src/certs/
-	mv "$client_cert" ../src/certs/
+	mkdir -p ./src/certs/
+	mv "$client_key" ./src/certs/
+	mv "$client_cert" ./src/certs/
 	# Give r-w execution to group's u:o so we can use it for dev! 
-	chmod 755 ../src/certs/"$client_key"
-	chmod 755 ../src/certs/"$client_cert"
+	chmod 755 ./src/certs/"$client_key"
+	chmod 755 ./src/certs/"$client_cert"
+	rm ./*.csr ./*.srl
 }
 
 # Print help for CLI
@@ -72,7 +73,7 @@ printHelp() {
 # Clean up artifacts.
 cleanup(){
 	rm -rf ./*.key ./*.crt ./*.csr ./*.srl
-	rm -rf ../src/certs/*.key ../src/certs/*.crt
+	rm -rf ./src/certs/*.key ./src/certs/*.crt
 }
 
 # Check if we are running as root

--- a/tools/createCA.sh
+++ b/tools/createCA.sh
@@ -25,7 +25,7 @@ createRootCACert(){
 		-sha"$sha_bits" -days "$expire" -out "$rootca_cert" 
 }
 
-# Create a certificate for development
+# Create a key for the client.
 createClientKey(){
 	openssl genrsa -out "$client_key" 
 }
@@ -48,16 +48,19 @@ acceptCSR(){
 		-days "$expire" -sha"$sha_bits"
 }
 
-# Log certificate out to stdout
+# Log certificate to stdout
 verifyCert(){
 	openssl x509 -in "$client_cert" -text -noout
 }
 
 # Install into certs folder
 installRootCA(){
+	printf "installing certs\n"
 	mkdir -p ../src/certs/
-	cp "$client_key" ../src/certs/
-	cp "$client_cert" ../src/certs/
+	mv "$client_key" ../src/certs/
+	mv "$client_cert" ../src/certs/
+	# Give r-w execution to group's u:o so we can use it for dev! 
+	chmod 755 -R ../src/certs/
 }
 
 # Print help for CLI
@@ -99,7 +102,7 @@ elif [ "$build" == "yes" ]; then
 	createClientCSR
 	acceptCSR
 	verifyCert
-	printf "installing certs\n"
+	installRootCA
 elif [ "$clean" == "yes" ]; then
 	printf "cleaning...\n"
 	cleanup

--- a/tools/createCA.sh
+++ b/tools/createCA.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+#timh|2020|MIT license
+
+# Override by running with ENV vars set.
+rootdomain="${ROOT_DOMAIN:-domain}"
+clientdomain="${CLIENT_DOMAIN:-localhost}"
+rootca_key="${ROOT_CA_KEY:-rootca.key}"
+rootca_cert="${ROOT_CA_CERT:-rootca.crt}"
+client_key="${CLIENT_KEY:-$clientdomain.key}"
+client_cert="${CLIENT_KEY:-$clientdomain.crt}"
+client_csr="${CLIENT_CSR:-$clientdomain.csr}"
+keysize="${KEYSIZE:-4096}"
+expire="${EXPIRE:-365}"
+sha_bits="${SHA_BITS:-256}"
+
+# Root CA key
+createRootCA(){
+	openssl genrsa -out "$rootca_key" "$keysize"
+}
+
+# Create the Root CA Certificate.
+createRootCACert(){
+	openssl req -x509 -new -nodes -key "$rootca_key" -subj "/C=SE/ST=Stockholm/O=Dev/CN=$rootdomain" \
+		-addext "subjectAltName = IP:127.0.0.1" \
+		-sha"$sha_bits" -days "$expire" -out "$rootca_cert" 
+}
+
+# Create a certificate for development
+createClientKey(){
+	openssl genrsa -out "$client_key" 
+}
+
+# Create a CSR (Certificate Signing Request)
+createClientCSR(){
+	openssl req -new -sha256 -key "$client_key" -subj "/C=SE/ST=Stockholm/O=Dev/CN=$clientdomain" -out "$client_csr"
+}
+
+# Log out CSR to stdout
+verifyClientCSR(){
+	openssl req -in "$client_csr" -noout -text
+}
+
+# Accept your own CSR with your rootca key.
+acceptCSR(){
+	openssl x509 -req -in "$client_csr" \
+		-CA "$rootca_cert" -CAkey "$rootca_key" \
+		-CAcreateserial -out "$client_cert" \
+		-days "$expire" -sha"$sha_bits"
+}
+
+# Log certificate out to stdout
+verifyCert(){
+	openssl x509 -in "$client_cert" -text -noout
+}
+
+# Install into certs folder
+installRootCA(){
+	mkdir -p ../src/certs/
+	cp "$client_key" ../src/certs/
+	cp "$client_cert" ../src/certs/
+}
+
+# Print help for CLI
+printHelp() {
+	printf "\nbuild -b [yes|no]\nclean -c [yes|no]\n" 
+}
+
+# Clean up artifacts.
+cleanup(){
+	rm -rf ./*.key ./*.crt ./*.csr ./*.srl
+	rm -rf ../src/certs/*.key ../src/certs/*.crt
+}
+
+# Check if we are running as root
+if [ "$EUID" -ne 0 ]; then
+	printf "Please run this script as root in order to install the development certificate\n"
+	exit 1
+fi
+
+# Parse flags
+while getopts :h:b:c: flag
+do
+	case "${flag}" in
+		h) helper=${OPTARG};;
+		b) build=${OPTARG};;
+		c) clean=${OPTARG};;
+		*) printHelp && exit 1;;
+	esac
+done
+
+# Act on flags
+if [ "$helper" != "" ] || [ "$build" == "" ] && [ "$clean" == "" ]; then
+	printHelp
+	exit 0
+elif [ "$build" == "yes" ]; then
+	createRootCA
+	createRootCACert
+	createClientKey
+	createClientCSR
+	acceptCSR
+	verifyCert
+	printf "installing certs\n"
+elif [ "$clean" == "yes" ]; then
+	printf "cleaning...\n"
+	cleanup
+fi
+
+printf "exiting...\n"
+exit 0


### PR DESCRIPTION
Creates a Root CA and server cert for the nodejs https module for development.
The script is flexible to change many parameters via the bash environment, but sane defaults are provided.
Added ./src/certs folder for organization.
Update app.js to point to appropriate location for generated certs.
Update README.md on script for development purposes. 